### PR TITLE
Update docs tags and structure

### DIFF
--- a/docs/How-To Articles/basic-syntax.md
+++ b/docs/How-To Articles/basic-syntax.md
@@ -1,5 +1,5 @@
 ---
-tags: [01. Using Markdown]
+tags: [How-To]
 ---
 
 # Markdown Basics

--- a/docs/Reference Articles/stoplight-flavored-markdown.md
+++ b/docs/Reference Articles/stoplight-flavored-markdown.md
@@ -1,5 +1,5 @@
 ---
-tags: [01. Using Markdown]
+tags: [Reference]
 ---
 
 # Stoplight Flavored Markdown (SMD)

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,5 +1,5 @@
 ---
-tags: [00. Welcome]
+tags: [Introduction]
 ---
 
 # Introduction

--- a/docs/ui-overview.md
+++ b/docs/ui-overview.md
@@ -1,6 +1,6 @@
 ---
 title: UI Overview
-tags: [00. Welcome]
+tags: [UX]
 ---
 
 # UI Overview


### PR DESCRIPTION
I updated my fork so the base demo presented better; specifically

- Change the generic "markdown" folder to "How-Tos" and added a directory called "Reference"
- Make the tags on markdown files to be more generally useful, e.g., tag "00. Welcome" to "Introduction" to tell the story that an Introduction article will be included in every project.